### PR TITLE
feat: solve message buffer pollution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project aims to adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.2.0] - 2026-01-06
 
 ### Added
 - Debug mode configuration option `turepo-debug-mode` to control message verbosity.
+- Private helper function (`turepo--message`) that intercepts all messages and prints them to message buffer conditionally.
 
 ### Changed
 - Removed almost all messages being sent to the end user in non-debug mode.
+- Migrated all message buffer print lines to use `turepo--message` helper function.
 
 ## [0.1.0] - 2025-12-27
 


### PR DESCRIPTION
- introduce a new config flag that the user can set to enable or disable debug messages
- this keeps the message buffer clean and only shows output incase a failure condition is met. this is in-line with how most unix programs operate
- also document the changes and add commentary on how to use the config option in your emacs config
- resolves #2